### PR TITLE
Add format conversion function for convenience

### DIFF
--- a/Sources/zkp/Asymmetric.swift
+++ b/Sources/zkp/Asymmetric.swift
@@ -217,6 +217,20 @@ public extension secp256k1 {
                     throw CryptoKitError.incorrectParameterSize
                 }
             }
+            
+            public func toFormat(_ format: secp256k1.Format) throws -> Self {
+                
+                let context = secp256k1.Context.rawRepresentation
+                var pubKey = rawRepresentation
+                var pubKeyLen = format.length
+                var pubKeyBytes = [UInt8](repeating: 0, count: pubKeyLen)
+                
+                guard secp256k1_ec_pubkey_serialize(context, &pubKeyBytes, &pubKeyLen, &pubKey, format.rawValue).boolValue else {
+                    throw secp256k1Error.underlyingCryptoError
+                }
+                
+                return try Self(dataRepresentation: pubKeyBytes, format: format)
+            }
         }
 
         /// The corresponding x-only public key for the secp256k1 curve.

--- a/Tests/zkpTests/secp256k1Tests.swift
+++ b/Tests/zkpTests/secp256k1Tests.swift
@@ -648,6 +648,13 @@ final class secp256k1Tests: XCTestCase, @unchecked Sendable {
 
         XCTAssertEqual(combinedKeyBytes, expectedCombinedKey)
     }
+    
+    func testKeyFormatConversion() throws {
+        let pubkey = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
+        let uncompressed = try pubkey.toFormat(.uncompressed)
+        XCTAssertEqual(String(bytes: uncompressed.bytes), "04a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba270b2031fef3acf8e13ea7a395e375491bdc37be1cd79e073d82bfd5ba8d35d68")
+        XCTAssertEqual(pubkey.dataRepresentation, try uncompressed.toFormat(.compressed).dataRepresentation)
+    }
 
     func testPrivateKeyPEM() {
         let privateKeyString = """


### PR DESCRIPTION
This PR proposes adding a convenience function allowing users to convert a compressed key into an uncompressed one and vice versa.
This is useful in cases where only the compressed version is provided, but the users needs to serialize to the full curve point (e.g. for DLEQ proof verification).